### PR TITLE
Update image playground handler for iOS 18.1 support and enhance error messaging

### DIFF
--- a/example/ios/reactnativeimageplaygroundexample.xcodeproj/project.pbxproj
+++ b/example/ios/reactnativeimageplaygroundexample.xcodeproj/project.pbxproj
@@ -12,13 +12,14 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		96905EF65AED1B983A6B3ABC /* libPods-reactnativeimageplaygroundexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-reactnativeimageplaygroundexample.a */; };
-		AB8FBCE0AD7F4BC4892BA179 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C08EF6CA9248E3B7A31DCE /* noop-file.swift */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
-		D7A4F1DD680DA4AE1D93737F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D55E2E613342BDF135DA3687 /* PrivacyInfo.xcprivacy */; };
+		F25FECD022A3C348C6B73E3C /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0AB1D740349DD4ECDF438D00 /* PrivacyInfo.xcprivacy */; };
+		FB74A1567DD74B0EA12D6863 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78C225210B3B456587227276 /* noop-file.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0AB1D740349DD4ECDF438D00 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = reactnativeimageplaygroundexample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* reactnativeimageplaygroundexample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = reactnativeimageplaygroundexample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = reactnativeimageplaygroundexample/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = reactnativeimageplaygroundexample/AppDelegate.mm; sourceTree = "<group>"; };
@@ -27,12 +28,11 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = reactnativeimageplaygroundexample/main.m; sourceTree = "<group>"; };
 		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-reactnativeimageplaygroundexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-reactnativeimageplaygroundexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C2E3173556A471DD304B334 /* Pods-reactnativeimageplaygroundexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnativeimageplaygroundexample.debug.xcconfig"; path = "Target Support Files/Pods-reactnativeimageplaygroundexample/Pods-reactnativeimageplaygroundexample.debug.xcconfig"; sourceTree = "<group>"; };
+		78C225210B3B456587227276 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "reactnativeimageplaygroundexample/noop-file.swift"; sourceTree = "<group>"; };
 		7A4D352CD337FB3A3BF06240 /* Pods-reactnativeimageplaygroundexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnativeimageplaygroundexample.release.xcconfig"; path = "Target Support Files/Pods-reactnativeimageplaygroundexample/Pods-reactnativeimageplaygroundexample.release.xcconfig"; sourceTree = "<group>"; };
-		A805D8140B3E46209068EBF7 /* reactnativeimageplaygroundexample-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "reactnativeimageplaygroundexample-Bridging-Header.h"; path = "reactnativeimageplaygroundexample/reactnativeimageplaygroundexample-Bridging-Header.h"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = reactnativeimageplaygroundexample/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		D55E2E613342BDF135DA3687 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = reactnativeimageplaygroundexample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		E2C08EF6CA9248E3B7A31DCE /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "reactnativeimageplaygroundexample/noop-file.swift"; sourceTree = "<group>"; };
+		CD8929D06E194BF2895CA309 /* reactnativeimageplaygroundexample-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "reactnativeimageplaygroundexample-Bridging-Header.h"; path = "reactnativeimageplaygroundexample/reactnativeimageplaygroundexample-Bridging-Header.h"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-reactnativeimageplaygroundexample/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -59,9 +59,9 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				E2C08EF6CA9248E3B7A31DCE /* noop-file.swift */,
-				A805D8140B3E46209068EBF7 /* reactnativeimageplaygroundexample-Bridging-Header.h */,
-				D55E2E613342BDF135DA3687 /* PrivacyInfo.xcprivacy */,
+				78C225210B3B456587227276 /* noop-file.swift */,
+				CD8929D06E194BF2895CA309 /* reactnativeimageplaygroundexample-Bridging-Header.h */,
+				0AB1D740349DD4ECDF438D00 /* PrivacyInfo.xcprivacy */,
 			);
 			name = reactnativeimageplaygroundexample;
 			sourceTree = "<group>";
@@ -147,13 +147,13 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "reactnativeimageplaygroundexample" */;
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
-				5C85A4FE21831C646978C300 /* [Expo] Configure project */,
+				6877479F24DD11624B9E0BBB /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				7BC4DDA57DADD0A76CB66C57 /* [CP] Embed Pods Frameworks */,
+				6D83CC633DCF117E20334D29 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -173,8 +173,8 @@
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = PVNM55SSDT;
 						LastSwiftMigration = 1250;
+						DevelopmentTeam = "PVNM55SSDT";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -205,7 +205,7 @@
 				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
-				D7A4F1DD680DA4AE1D93737F /* PrivacyInfo.xcprivacy in Resources */,
+				F25FECD022A3C348C6B73E3C /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -249,7 +249,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5C85A4FE21831C646978C300 /* [Expo] Configure project */ = {
+		6877479F24DD11624B9E0BBB /* [Expo] Configure project */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -268,7 +268,7 @@
 			shellPath = /bin/sh;
 			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-reactnativeimageplaygroundexample/expo-configure-project.sh\"\n";
 		};
-		7BC4DDA57DADD0A76CB66C57 /* [CP] Embed Pods Frameworks */ = {
+		6D83CC633DCF117E20334D29 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -322,7 +322,7 @@
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */,
-				AB8FBCE0AD7F4BC4892BA179 /* noop-file.swift in Sources */,
+				FB74A1567DD74B0EA12D6863 /* noop-file.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,10 +336,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = reactnativeimageplaygroundexample/reactnativeimageplaygroundexample.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = PVNM55SSDT;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -362,6 +359,9 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
+				DEVELOPMENT_TEAM = "PVNM55SSDT";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Debug;
 		};
@@ -372,10 +372,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = reactnativeimageplaygroundexample/reactnativeimageplaygroundexample.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = PVNM55SSDT;
 				INFOPLIST_FILE = reactnativeimageplaygroundexample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -392,6 +389,9 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
+				DEVELOPMENT_TEAM = "PVNM55SSDT";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Release;
 		};

--- a/ios/ReactNativeImagePlaygroundModule.swift
+++ b/ios/ReactNativeImagePlaygroundModule.swift
@@ -14,7 +14,7 @@ public class ReactNativeImagePlaygroundModule: Module {
 
     AsyncFunction("launchImagePlaygroundAsync") { () -> [String: Any] in
       if #available(iOS 18.1, *) {
-        self.handler = ImagePlayground18Handler(appContext: self.appContext)
+        self.handler = SupportedImagePlaygroundHandler(appContext: self.appContext)
       } else {
         self.handler = UnsupportedImagePlaygroundHandler(appContext: self.appContext)
       }
@@ -39,8 +39,9 @@ class UnsupportedImagePlaygroundHandler: ImagePlaygroundHandler {
         }
 
         let alert = UIAlertController(
-          title: "サポート対象外",
-          message: "Image Playgroundはこのデバイスではサポートされていません",
+          title: "Image Playground is not available",
+          message:
+            "Image Playground is only available on iOS 18.1 and later, and is supported on iPhone 15 Pro, iPhone 15 Pro Max, and iPhone 16 series.",
           preferredStyle: .alert
         )
         alert.addAction(
@@ -55,7 +56,7 @@ class UnsupportedImagePlaygroundHandler: ImagePlaygroundHandler {
 }
 
 @available(iOS 18.1, *)
-class ImagePlayground18Handler: ImagePlaygroundHandler {
+class SupportedImagePlaygroundHandler: ImagePlaygroundHandler {
   private weak var appContext: AppContext?
   private var delegate: ImagePlaygroundDelegate?
   @Environment(\.supportsImagePlayground) private var supportsImagePlayground
@@ -111,7 +112,7 @@ class ImagePlayground18Handler: ImagePlaygroundHandler {
       _ imagePlaygroundViewController: ImagePlaygroundViewController
     ) {
       imagePlaygroundViewController.dismiss(animated: true)
-      completion(.failure(NSError(domain: "ReactNativeImagePlayground", code: -2)))
+      completion(.success([:]))
     }
   }
 }


### PR DESCRIPTION
Improve the image playground handler to support iOS 18.1 and provide clearer error messages for unsupported devices.