### PR TITLE
Update package name and add platform check for iOS Image Playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-native-image-playground",
+  "name": "react-native-apple-image-playground",
   "version": "0.1.0",
-  "description": "My new module",
+  "description": "React Native module for iOS Image Playground - Create stunning images with Apple's Image Playground on iPhone 15 Pro and later",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { requireNativeModule } from "expo-modules-core";
+import { Platform, Alert } from "react-native";
 
 import { ImagePlaygroundModuleType, ImagePlaygroundResult } from "./index.type";
 
@@ -7,6 +8,15 @@ const imagePlaygroundModule = requireNativeModule(
 ) as ImagePlaygroundModuleType;
 
 const launchImagePlaygroundAsync = async (): Promise<string | undefined> => {
+  if (Platform.OS === "android") {
+    Alert.alert(
+      "Apple Platform Only",
+      "This Image Playground feature uses Apple Intelligence and is only available on iOS devices.",
+      [{ text: "Close" }],
+    );
+    return;
+  }
+
   const res: ImagePlaygroundResult =
     await imagePlaygroundModule.launchImagePlaygroundAsync();
   return res.url;


### PR DESCRIPTION
Change the package name and description to reflect iOS exclusivity, and implement a platform check to alert Android users that the feature is only available on iOS.